### PR TITLE
Fix permissions returned the wrong mode.

### DIFF
--- a/RootTools/src/com/stericson/RootTools/internal/RootToolsInternalMethods.java
+++ b/RootTools/src/com/stericson/RootTools/internal/RootToolsInternalMethods.java
@@ -31,6 +31,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.TimeoutException;
 import java.util.regex.Matcher;
@@ -145,6 +146,7 @@ public final class RootToolsInternalMethods {
     }
 
     public int parsePermissions(String permission) {
+        permission = permission.toLowerCase(Locale.US);
         int tmp;
         if (permission.charAt(0) == 'r')
             tmp = 4;
@@ -162,7 +164,8 @@ public final class RootToolsInternalMethods {
         RootTools.log("permission " + tmp);
         RootTools.log("character " + permission.charAt(1));
 
-        if (permission.charAt(2) == 'x')
+        if (permission.charAt(2) == 'x' || permission.charAt(2) == 's' 
+                || permission.charAt(2) == 't')
             tmp += 1;
         else
             tmp += 0;


### PR DESCRIPTION
permission string should be lowercase to parse possible uppercase sticky bit. Even though you are parsing special permissions in `parseSpecialPermissions(String permission)` this was not adding 1 where needed.
