### PR TITLE
Fixed NullPointerExceptions on Windows and created Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+RootTools
+=========
+
+RootTools provides rooted developers a standardized set of tools for use in the development of rooted applications. In the end, we will accomplish this by providing developers with robust, easy-to-use libraries that will drastically improve development times as well as promote code reuse. This project is open to any proven developer that feels they have something to contribute. By pitching in together we can streamline our own processes, improve the effectiveness of our apps, learn new techniques, and provide a better experience for our users.
+
+You can find the latest release here: https://github.com/Stericson/RootTools/releases

--- a/RootTools/src/com/stericson/RootTools/containers/RootClass.java
+++ b/RootTools/src/com/stericson/RootTools/containers/RootClass.java
@@ -160,7 +160,7 @@ public class RootClass /* #ANNOTATIONS extends AbstractProcessor */
                 {
                 }
 
-                File rawFolder = new File("res/raw");
+                File rawFolder = new File("res" + File.separator + "raw");
                 if (!rawFolder.exists())
                 {
                     rawFolder.mkdirs();
@@ -172,7 +172,7 @@ public class RootClass /* #ANNOTATIONS extends AbstractProcessor */
                 {
                     cmd = new String[]{
                             "cmd", "/C",
-                            "dx --dex --output=res/raw/anbuild.dex "
+                            "dx --dex --output=res" + File.separator + "raw" + File.separator + "anbuild.dex "
                                     + builtPath + File.separator + "anbuild.jar"
                     };
                 }
@@ -181,7 +181,7 @@ public class RootClass /* #ANNOTATIONS extends AbstractProcessor */
                     cmd = new String[]{
                             getPathToDx(),
                             "--dex",
-                            "--output=res/raw/anbuild.dex",
+                            "--output=res" + File.separator + "raw" + File.separator + "anbuild.dex",
                             builtPath + File.separator + "anbuild.jar"
                     };
                 }
@@ -197,12 +197,12 @@ public class RootClass /* #ANNOTATIONS extends AbstractProcessor */
                 {
                 }
             }
-            System.out.println("All done. ::: anbuild.dex should now be in your project's res/raw/ folder :::");
+            System.out.println("All done. ::: anbuild.dex should now be in your project's res" + File.separator + "raw" + File.separator + " folder :::");
         }
 
         protected void lookup(File path, List<File> fileList)
         {
-            String desourcedPath = path.toString().replace("src/", "");
+            String desourcedPath = path.toString().replace("src" + File.separator, "");
             File[] files = path.listFiles();
             for (File file : files)
             {


### PR DESCRIPTION
Windows is DOS based and uses different (from unix) directory separators. This causes NullPointerExceptions in RootClass. Should also fix Stericson/RootTools#16

Also copied wiki root to Readme.