### PR TITLE
Grep for the process name in isProcessRunning

### DIFF
--- a/src/main/java/com/stericson/RootTools/internal/RootToolsInternalMethods.java
+++ b/src/main/java/com/stericson/RootTools/internal/RootToolsInternalMethods.java
@@ -1156,7 +1156,7 @@ public final class RootToolsInternalMethods {
         InternalVariables.processRunning = false;
 
         try {
-            Command command = new Command(0, false, "ps") {
+            Command command = new Command(0, false, "ps | grep " + processName) {
                 @Override
                 public void commandOutput(int id, String line) {
                     if (line.contains(processName)) {


### PR DESCRIPTION
This improves performance, without doing this, hundreds of lines from standard output are processed instead of one (or none).