### PR TITLE
update gradle plugin to 3.1.3 and gradle to 4.8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 buildscript {
     repositories {
+        google()
         jcenter()
     }
 
@@ -8,7 +9,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.2'
+        classpath 'com.android.tools.build:gradle:3.1.3'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
     }
 }
@@ -21,7 +22,6 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.3"
 
     defaultConfig {
         minSdkVersion 11
@@ -36,7 +36,7 @@ android {
 }
 
 dependencies {
-    compile project(':RootShell')
-    testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:25.3.1'
+    implementation project(':RootShell')
+    testImplementation 'junit:junit:4.12'
+    implementation 'com.android.support:appcompat-v7:25.3.1'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue May 02 15:22:41 SGT 2017
+#Wed Jul 04 17:42:21 CEST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.8-all.zip


### PR DESCRIPTION
I tried to use an artifactory publish plugin (`guru.stefma.artifactorypublish:artifactorypublish:0.0.4`) to upload the lib to our company internal Artifactory.
Unfortunately the plugin didn't work well with current gradle plugin version in the project (2.3.2) so I upgraded the plugin to 3.1.3 (and Gradle to 4.8).
I also removed the `buildToolsVersion` as the new gradle plugins have now default buildToolsVersion defined.